### PR TITLE
Upstream PR: Allow hidden input to be optional

### DIFF
--- a/src/autocomplete.mjs
+++ b/src/autocomplete.mjs
@@ -120,7 +120,7 @@ export default class extends Controller {
     const value = selected.getAttribute('data-autocomplete-value') || textValue
     this.inputTarget.value = textValue
 
-    if ( this.hiddenTarget ) {
+    if ( this.hasHiddenTarget ) {
       this.hiddenTarget.value = value
     } else {
       this.inputTarget.value = value


### PR DESCRIPTION
Pulled from https://github.com/afcapel/stimulus-autocomplete/pull/5

>Small change that makes the hidden target an optional in the html.
Calling `this.hiddenTarget` was throwing and error when the hidden tag
was not defined.

